### PR TITLE
Add support for multiple dictionaries

### DIFF
--- a/addon/appModules/perky.py
+++ b/addon/appModules/perky.py
@@ -82,7 +82,7 @@ class PerkySpeechSymbolsDialog(SpeechSymbolsDialog):
 		bHelper.addButton(
 			parent=self,
 			# Translators: The label for a button in the Perky speech symbols dialog.
-			label=_("&Save dictionary...")
+			label=_("Save dictio&nary...")
 		).Bind(wx.EVT_BUTTON, self.onSaveClick)
 		bHelper.addButton(
 			parent=self,

--- a/addon/appModules/perky.py
+++ b/addon/appModules/perky.py
@@ -5,6 +5,7 @@
 # Released under GPL 2
 
 import os
+import wx
 
 import addonHandler
 import appModuleHandler
@@ -22,9 +23,12 @@ from NVDAObjects.behaviors import EditableTextWithAutoSelectDetection, KeyboardH
 from NVDAObjects.IAccessible import IAccessible, ContentGenericClient
 import controlTypes
 import gui
+from gui import guiHelper
 from gui.settingsDialogs import SpeechSymbolsDialog
 
 SYMBOLS_DIR = "symbols"
+
+pathToDict = None
 
 addonHandler.initTranslation()
 
@@ -37,7 +41,7 @@ def disableInSecureMode(decoratedCls):
 
 class SymbolProcessor:
 
-	def __init__(self):
+	def __init__(self, pathToDict=None):
 		characterProcessing.clearSpeechSymbols()
 		try:
 			symbolProcessor = characterProcessing._localeSpeechSymbolProcessors.fetchLocaleData(
@@ -45,9 +49,10 @@ class SymbolProcessor:
 			)
 		except LookupError:
 			symbolProcessor = characterProcessing._localeSpeechSymbolProcessors.fetchLocaleData("en")
-		pathToDict = os.path.join(
-			os.path.dirname(__file__), SYMBOLS_DIR, os.path.basename(symbolProcessor.userSymbols.fileName)
-		)
+		if pathToDict is None:
+			pathToDict = os.path.join(
+				os.path.dirname(__file__), SYMBOLS_DIR, os.path.basename(symbolProcessor.userSymbols.fileName)
+			)
 		self.pathToDict = pathToDict
 		try:
 			symbolProcessor.userSymbols.load(pathToDict)
@@ -65,7 +70,52 @@ class PerkySpeechSymbolsDialog(SpeechSymbolsDialog):
 		super().__init__(
 			parent,
 		)
-		self.SetTitle(f"Perky - {self.title}")
+		if pathToDict is not None:
+			dictName = os.path.splitext(os.path.basename(pathToDict))[0]
+		else:
+			dictName = ""
+		self.SetTitle(f"Perky {dictName} - {self.title}")
+
+	def makeSettings(self, settingsSizer):
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+		bHelper = guiHelper.ButtonHelper(orientation=wx.HORIZONTAL)
+		bHelper.addButton(
+			parent=self,
+			# Translators: The label for a button in the Perky speech symbols dialog.
+			label=_("&Save dictionary...")
+		).Bind(wx.EVT_BUTTON, self.onSaveClick)
+		bHelper.addButton(
+			parent=self,
+			# Translators: The label for a button in the Perky speech symbols dialog.
+			label=_("&Choose dictionary...")
+		).Bind(wx.EVT_BUTTON, self.onOpenClick)
+		sHelper.addItem(bHelper)
+		super().makeSettings(settingsSizer)
+
+	def onSaveClick(self, evt):
+		filename = wx.FileSelector(
+			_("Save As"), default_filename="newSpeechSymbols.dic", default_path=os.path.join(os.path.dirname(__file__), SYMBOLS_DIR),
+			flags=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT, parent=self
+		)
+		if not filename:
+			return
+		global pathToDict
+		pathToDict = filename
+		self.symbolProcessor.userSymbols.fileName = filename
+		dictName = os.path.splitext(os.path.basename(pathToDict))[0]
+		self.symbolsList.SetFocus()
+		self.SetTitle(f"Perky {dictName} - {self.title}")
+
+	def onOpenClick(self, evt):
+		filename = wx.FileSelector(
+			_("Select dictionary..."), default_path=os.path.join(os.path.dirname(__file__), SYMBOLS_DIR),
+			flags=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST, parent=self
+		)
+		if not filename:
+			return
+		global pathToDict
+		pathToDict = filename
+		super().onCancel(evt)
 
 
 class EnhancedDocument(KeyboardHandlerBasedTypedCharSupport):
@@ -82,7 +132,7 @@ class EnhancedDocument(KeyboardHandlerBasedTypedCharSupport):
 	def event_gainFocus(self):
 		super().event_gainFocus()
 		self._shouldReportChars = 0
-		self.customProcessor = SymbolProcessor()
+		self.customProcessor = SymbolProcessor(pathToDict)
 
 	def event_loseFocus(self):
 		super().event_loseFocus()

--- a/addon/appModules/perky.py
+++ b/addon/appModules/perky.py
@@ -94,7 +94,8 @@ class PerkySpeechSymbolsDialog(SpeechSymbolsDialog):
 
 	def onSaveClick(self, evt):
 		filename = wx.FileSelector(
-			_("Save As"), default_filename="newSpeechSymbols.dic", default_path=os.path.join(os.path.dirname(__file__), SYMBOLS_DIR),
+			_("Save As"), default_filename="newSpeechSymbols.dic",
+			default_path=os.path.join(os.path.dirname(__file__), SYMBOLS_DIR),
 			flags=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT, parent=self
 		)
 		if not filename:

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,6 @@ This add-on is used to improve the reading experience with Perky Duck, available
 
 The following commands can be assigned from NVDA's menu, Preferences submenu, Input gestures dialog, Perky Duck category. This will be available from Perky Duck documents:
 
-* Opens the symbols dialog for reading characters typed in Perky.
+* Opens the symbols dialog for reading characters typed in Perky. From this dialog, you can save and choose symbols dictionaries.
 * Shows the selected text converted to braille using symbols for the current language.
 * Shows the selected text in browse mode.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Users may want to have multiple dictionaries, for example for stenographic braille.
### Description of how this pull request fixes the issue:
Two new buttons have been added to the Perky symbols dialog to save (create a new dictionary or replace an existing one), and to select the dictionary to be used.

A global variable pathToDict has been created to hold the path of the used dictionary.

The SymbolsProcessor class now accept a pathToDict argument.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None since this add-on hasn't been published in the stable version. Documentation will be updated.